### PR TITLE
Case sensitive binding

### DIFF
--- a/Source/TinyMapper/Bindings/BindingConfigOf.cs
+++ b/Source/TinyMapper/Bindings/BindingConfigOf.cs
@@ -10,7 +10,7 @@ namespace Nelibur.ObjectMapper.Bindings
             string sourceName = GetMemberInfo(source);
             string targetName = GetMemberInfo(target);
 
-            if (string.Equals(sourceName, targetName, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(sourceName, targetName, StringComparison.Ordinal))
             {
                 return;
             }

--- a/Source/UnitTests/Mappings/MappingWithConfigTests.cs
+++ b/Source/UnitTests/Mappings/MappingWithConfigTests.cs
@@ -37,6 +37,26 @@ namespace UnitTests.Mappings
             Assert.Equal(source.SourceItem.Id, actual.TargetItem.Id);
         }
 
+		[Fact]
+		public void Map_BindCaseSensitive_Success()
+		{
+			TinyMapper.Bind<SourceItem, TargetItem>();
+
+			TinyMapper.Bind<Source1, Target1>(config =>
+			{
+				config.Bind(from => from.CaseSensitive, to => to.Casesensitive);
+			});
+
+			var source = new Source1
+			{
+				CaseSensitive = "CaseSensitive"
+			};
+
+			var actual = TinyMapper.Map<Target1>(source);
+
+			Assert.Equal(source.CaseSensitive, actual.Casesensitive);
+		}
+
         [Fact]
         public void Map_ConcreteType_Success()
         {
@@ -88,6 +108,7 @@ namespace UnitTests.Mappings
             public bool Bool { get; set; }
             public byte Byte { get; set; }
             public int Int { get; set; }
+			public string CaseSensitive { get; set; }
 
             public SourceItem SourceItem { get; set; }
             public string String { get; set; }
@@ -110,6 +131,7 @@ namespace UnitTests.Mappings
             public byte Byte { get; set; }
             public int MyInt { get; set; }
             public string MyString { get; set; }
+			public string Casesensitive { get; set; }
 
             public TargetItem TargetItem { get; set; }
         }

--- a/Source/UnitTests/Mappings/MappingWithConfigTests.cs
+++ b/Source/UnitTests/Mappings/MappingWithConfigTests.cs
@@ -37,25 +37,25 @@ namespace UnitTests.Mappings
             Assert.Equal(source.SourceItem.Id, actual.TargetItem.Id);
         }
 
-		[Fact]
-		public void Map_BindCaseSensitive_Success()
-		{
-			TinyMapper.Bind<SourceItem, TargetItem>();
+        [Fact]
+        public void Map_BindCaseSensitive_Success()
+        {
+            TinyMapper.Bind<SourceItem, TargetItem>();
 
-			TinyMapper.Bind<Source1, Target1>(config =>
-			{
-				config.Bind(from => from.CaseSensitive, to => to.Casesensitive);
-			});
+            TinyMapper.Bind<Source1, Target1>(config =>
+            {
+                config.Bind(from => from.CaseSensitive, to => to.Casesensitive);
+            });
 
-			var source = new Source1
-			{
-				CaseSensitive = "CaseSensitive"
-			};
+            var source = new Source1
+            {
+                CaseSensitive = "CaseSensitive"
+            };
 
-			var actual = TinyMapper.Map<Target1>(source);
+            var actual = TinyMapper.Map<Target1>(source);
 
-			Assert.Equal(source.CaseSensitive, actual.Casesensitive);
-		}
+            Assert.Equal(source.CaseSensitive, actual.Casesensitive);
+        }
 
         [Fact]
         public void Map_ConcreteType_Success()
@@ -108,7 +108,7 @@ namespace UnitTests.Mappings
             public bool Bool { get; set; }
             public byte Byte { get; set; }
             public int Int { get; set; }
-			public string CaseSensitive { get; set; }
+            public string CaseSensitive { get; set; }
 
             public SourceItem SourceItem { get; set; }
             public string String { get; set; }
@@ -131,7 +131,7 @@ namespace UnitTests.Mappings
             public byte Byte { get; set; }
             public int MyInt { get; set; }
             public string MyString { get; set; }
-			public string Casesensitive { get; set; }
+            public string Casesensitive { get; set; }
 
             public TargetItem TargetItem { get; set; }
         }


### PR DESCRIPTION
Binding config would ignore properties with same name but different case.
Since c# is a casse sensitive language, we need to be able to map s.FirstName to t.Firstname