### PR TITLE
Global names mapping via convictions

### DIFF
--- a/Source/TinyMapper/GlobalConfiguration.cs
+++ b/Source/TinyMapper/GlobalConfiguration.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Nelibur.ObjectMapper.Mappers;
+
+namespace Nelibur.ObjectMapper
+{
+    internal class GlobalConfiguration : IGlobalConfiguration
+    {
+        private readonly TargetMapperBuilder _targetMapperBuilder;
+
+        public GlobalConfiguration(TargetMapperBuilder targetMapperBuilder)
+        {
+            if (targetMapperBuilder == null)
+                throw new ArgumentNullException(nameof(targetMapperBuilder));
+
+            _targetMapperBuilder = targetMapperBuilder;
+        }
+
+        public void ChangeNameMatching(Func<string, string, bool> nameMatching)
+        {
+            if (nameMatching == null)
+                throw new ArgumentNullException(nameof(nameMatching));
+
+            _targetMapperBuilder.IsNameMatched = nameMatching;
+        }
+
+        public void Reset()
+        {
+            _targetMapperBuilder.IsNameMatched = TargetMapperBuilder.DefaultMatching;
+        }
+    }
+}

--- a/Source/TinyMapper/IGlobalConfiguration.cs
+++ b/Source/TinyMapper/IGlobalConfiguration.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Nelibur.ObjectMapper
+{
+    public interface IGlobalConfiguration
+    {
+        void Reset();
+        void ChangeNameMatching(Func<string, string, bool> nameMatching);
+    }
+}

--- a/Source/TinyMapper/Mappers/Classes/Members/MappingMemberBuilder.cs
+++ b/Source/TinyMapper/Mappers/Classes/Members/MappingMemberBuilder.cs
@@ -10,7 +10,9 @@ namespace Nelibur.ObjectMapper.Mappers.Classes.Members
 {
     internal sealed class MappingMemberBuilder
     {
+        
         private readonly IMapperBuilderConfig _config;
+
 
         public MappingMemberBuilder(IMapperBuilderConfig config)
         {
@@ -67,11 +69,6 @@ namespace Nelibur.ObjectMapper.Mappers.Classes.Members
                 result.Add(member);
             }
             return result;
-        }
-
-        private static bool Match(string valueA, string valueB)
-        {
-            return string.Equals(valueA, valueB, StringComparison.Ordinal);
         }
 
         private string GetTargetName(
@@ -162,8 +159,9 @@ namespace Nelibur.ObjectMapper.Mappers.Classes.Members
                 }
 
                 string targetName = GetTargetName(bindingConfig, typePair, sourceMember, targetBindings);
+                MemberInfo targetMember = targetMembers.FirstOrDefault(x =>
+                                                        _config.IsNameMatched(targetName, x.Name));
 
-                MemberInfo targetMember = targetMembers.FirstOrDefault(x => Match(x.Name, targetName));
                 if (targetMember.IsNull())
                 {
                     continue;

--- a/Source/TinyMapper/Mappers/IMapperBuilderConfig.cs
+++ b/Source/TinyMapper/Mappers/IMapperBuilderConfig.cs
@@ -12,5 +12,7 @@ namespace Nelibur.ObjectMapper.Mappers
         Option<BindingConfig> GetBindingConfig(TypePair typePair);
         MapperBuilder GetMapperBuilder(TypePair typePair);
         MapperBuilder GetMapperBuilder(TypePair parentTypePair, MappingMember mappingMember);
+
+        Func<string, string, bool> IsNameMatched { get; }
     }
 }

--- a/Source/TinyMapper/Mappers/TargetMapperBuilder.cs
+++ b/Source/TinyMapper/Mappers/TargetMapperBuilder.cs
@@ -14,11 +14,19 @@ namespace Nelibur.ObjectMapper.Mappers
 {
     internal sealed class TargetMapperBuilder : IMapperBuilderConfig
     {
+        internal static readonly Func<string, string, bool> DefaultMatching =
+                    (source, target) => string.Equals(source, target, StringComparison.Ordinal);
+
         private readonly Dictionary<TypePair, BindingConfig> _bindingConfigs = new Dictionary<TypePair, BindingConfig>();
         private readonly ClassMapperBuilder _classMapperBuilder;
         private readonly CollectionMapperBuilder _collectionMapperBuilder;
         private readonly ConvertibleTypeMapperBuilder _convertibleTypeMapperBuilder;
         private readonly CustomTypeMapperBuilder _customTypeMapperBuilder;
+
+        public Func<string, string, bool> IsNameMatched
+        {
+            get; internal set;
+        }
 
         public TargetMapperBuilder(IDynamicAssembly assembly)
         {
@@ -28,6 +36,8 @@ namespace Nelibur.ObjectMapper.Mappers
             _collectionMapperBuilder = new CollectionMapperBuilder(this);
             _convertibleTypeMapperBuilder = new ConvertibleTypeMapperBuilder(this);
             _customTypeMapperBuilder = new CustomTypeMapperBuilder(this);
+
+            this.IsNameMatched = DefaultMatching;
         }
 
         public IDynamicAssembly Assembly { get; private set; }

--- a/Source/TinyMapper/TinyMapper.cs
+++ b/Source/TinyMapper/TinyMapper.cs
@@ -14,10 +14,14 @@ namespace Nelibur.ObjectMapper
         private static readonly Dictionary<TypePair, Mapper> _mappers = new Dictionary<TypePair, Mapper>();
         private static readonly TargetMapperBuilder _targetMapperBuilder;
 
+        public static readonly IGlobalConfiguration Config;
+
         static TinyMapper()
         {
             IDynamicAssembly assembly = DynamicAssemblyBuilder.Get();
             _targetMapperBuilder = new TargetMapperBuilder(assembly);
+
+            Config = new GlobalConfiguration(_targetMapperBuilder);
         }
 
         public static void Bind<TSource, TTarget>()

--- a/Source/TinyMapper/TinyMapper.csproj
+++ b/Source/TinyMapper/TinyMapper.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>Nelibur.ObjectMapper</RootNamespace>
     <AssemblyName>TinyMapper</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-	<TargetFrameworkProfile />
+    <TargetFrameworkProfile />
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -42,8 +42,8 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
-	<TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-	<TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release 3.5|AnyCPU'">
     <OutputPath>..\..\Out\Release\TinyMapper\3.5\</OutputPath>
@@ -55,7 +55,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
-	<TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release 3.0|AnyCPU'">
     <OutputPath>..\..\Out\Release\TinyMapper\3.0\</OutputPath>
@@ -67,7 +67,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
-	<TargetFrameworkVersion>v3.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.0</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -84,6 +84,8 @@
     <Compile Include="CodeGenerators\Emitters\EmitArray.cs" />
     <Compile Include="CodeGenerators\Emitters\EmitThis.cs" />
     <Compile Include="Core\Extensions\DictionaryExtensions.cs" />
+    <Compile Include="GlobalConfiguration.cs" />
+    <Compile Include="IGlobalConfiguration.cs" />
     <Compile Include="Mappers\Classes\ClassMapper.cs" />
     <Compile Include="Mappers\Classes\ClassMapperBuilder.cs" />
     <Compile Include="Mappers\Classes\Members\MemberEmitterDescription.cs" />

--- a/Source/UnitTests/GlobalConfigTests.cs
+++ b/Source/UnitTests/GlobalConfigTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Nelibur.ObjectMapper;
+using Xunit;
+
+namespace UnitTests.Mappings
+{
+    public class GlobalConfigTests
+    {
+        [Fact(DisplayName = "Checks if the Name-Mating is used.")]
+        public void CustomeMatching_Success()
+        {
+            TinyMapper.Config.ChangeNameMatching((s, t) => string.Equals(s + "1", t, StringComparison.OrdinalIgnoreCase));
+
+            var source = new SourceCustom() { Name= "Hallo" };
+            var result = new TargetCustom();
+            TinyMapper.Map(source, result );
+
+            Assert.Equal(source.Name, result.Name1);
+
+            TinyMapper.Config.Reset();
+        }
+
+        public class SourceCustom
+        {
+            public string Name { get; set; }
+        }
+
+
+        public class TargetCustom
+        {
+            public string Name1 { get; set; }
+        }
+
+    }
+}

--- a/Source/UnitTests/MappingBuilderConfigStub.cs
+++ b/Source/UnitTests/MappingBuilderConfigStub.cs
@@ -26,6 +26,14 @@ namespace UnitTests
             get { return DynamicAssemblyBuilder.Get(); }
         }
 
+        public Func<string, string, bool> IsNameMatched
+        {
+            get
+            {
+                return TargetMapperBuilder.DefaultMatching;
+            }
+        }
+
         public Option<BindingConfig> GetBindingConfig(TypePair typePair)
         {
             return _bindingConfig;

--- a/Source/UnitTests/UnitTests.csproj
+++ b/Source/UnitTests/UnitTests.csproj
@@ -115,7 +115,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Source/UnitTests/UnitTests.csproj
+++ b/Source/UnitTests/UnitTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,7 +12,8 @@
     <AssemblyName>UnitTests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>692d7b07</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
@@ -82,9 +84,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Mappings\Attributes\MappingWithGenericTypeTests.cs" />
     <Compile Include="Mappings\Collections\CollectionMappingTests.cs" />
     <Compile Include="Mappings\MapWithCustomBindTests.cs" />
+    <Compile Include="GlobalConfigTests.cs" />
     <Compile Include="Mappings\TypeConverters\ConvertibleTypeMappingTests.cs" />
     <Compile Include="Mappings\Collections\DictionaryMappingTests.cs" />
     <Compile Include="Mappings\Classes\ClassHierarchyMappingTests.cs" />
@@ -125,6 +127,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <Import Project="..\..\packages\AutoMapper.3.3.0\tools\AutoMapper.targets" Condition="Exists('..\..\packages\AutoMapper.3.3.0\tools\AutoMapper.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/UnitTests/packages.config
+++ b/Source/UnitTests/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Global names mapping via convictions. e.g.

```
ObjectA.Name -> ObjectB.Name1,
ObjectA.Titel -> ObjectB.Titel1
```

You can use to archiv it:
`
TinyMapper.Config.ChangeNameMatching((s, t) => string.Equals(s + "1", t, StringComparison.OrdinalIgnoreCase));`
