### PR TITLE
Added method BindIfNotBound which only adds a binding if it doesnt al…

### DIFF
--- a/Source/TinyMapper/TinyMapper.cs
+++ b/Source/TinyMapper/TinyMapper.cs
@@ -29,6 +29,16 @@ namespace Nelibur.ObjectMapper
             _mappers[typePair] = _targetMapperBuilder.Build(typePair);
         }
 
+        public static void BindIfNotBound<TSource, TTarget>(Action<IBindingConfig<TSource, TTarget>> config)
+        {
+            Mapper mapper;
+            TypePair typePair = TypePair.Create<TSource, TTarget>();
+            if (_mappers.TryGetValue(typePair, out mapper) == false)
+            {
+                Bind(config);
+            }
+        }
+
         public static void Bind<TSource, TTarget>(Action<IBindingConfig<TSource, TTarget>> config)
         {
             TypePair typePair = TypePair.Create<TSource, TTarget>();
@@ -52,6 +62,13 @@ namespace Nelibur.ObjectMapper
         public static void Config(Action<ITinyMapperConfig> config)
         {
             config(_config);
+        }
+
+        public static bool IsBound<TSource, TTarget>()
+        {
+            Mapper mapper;
+            TypePair typePair = TypePair.Create<TSource, TTarget>();
+            return _mappers.TryGetValue(typePair, out mapper);
         }
 
         /// <summary>

--- a/Source/UnitTests/Mappings/MappingWithConfigTests.cs
+++ b/Source/UnitTests/Mappings/MappingWithConfigTests.cs
@@ -105,6 +105,36 @@ namespace UnitTests.Mappings
             Assert.Null(actual.TargetItem);
         }
 
+
+        [Fact]
+        public void Map_BindIfNotBound_Success()
+        {
+            TinyMapper.Bind<Source1, Target1>(config =>
+            {
+                config.Ignore(x => x.Int);
+            });
+            TinyMapper.BindIfNotBound<Source1, Target1>(config =>
+            {
+                config.Ignore(x => x.Bool);
+            });
+
+            var source = new Source1
+            {
+                Bool = true,
+                Byte = 5,
+                Int = 9,
+                String = "Test",
+            };
+
+            var actual = TinyMapper.Map<Target1>(source);
+
+            Assert.Equal(source.Bool, actual.Bool);
+            Assert.Equal(null, actual.MyString);
+            Assert.Equal(source.Byte, actual.Byte);
+            Assert.Equal(0, actual.MyInt);
+            Assert.Null(actual.TargetItem);
+        }
+
         public class Source1
         {
             public bool Bool { get; set; }

--- a/Source/UnitTests/Mappings/PrimitiveTypeMappingTests.cs
+++ b/Source/UnitTests/Mappings/PrimitiveTypeMappingTests.cs
@@ -52,6 +52,14 @@ namespace UnitTests.Mappings
         }
 
         [Fact]
+        public void Map_IsBound_Success()
+        {
+            TinyMapper.Bind<Source2, Target2>();
+            
+            Assert.True(TinyMapper.IsBound<Source2, Target2>());
+        }
+
+        [Fact]
         public void Map_IgnoreProperties_Success()
         {
             TinyMapper.Bind<Source2, Target2>(config =>


### PR DESCRIPTION
Added method BindIfNotBound which only adds a binding if it doesnt already exist.

Also added a check for whether a binding has already been bound to
This allows multiple calls without consequence.

I have some nasty code I cannot guarantee multiple calls from and would like a way that i don't break things if that happens