### PR TITLE
Adding ThreadSafety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ _ReSharper*
 *.ncrunchproject
 /packages/*/*
 /Tools/*/*
+/.vs


### PR DESCRIPTION
This is a fix for bug #45 and also Bind not being thread-safe. Highly efficient reader-writer locking was added to the main class for the Bind methods as well as the GetMapper private static method. 

There is no good way to unit test this, but all tests are passing.