### PR TITLE
Added Polymorphic mapping for compatibility with Entity Framework

### DIFF
--- a/Source/TinyMapper/Bindings/BindingException.cs
+++ b/Source/TinyMapper/Bindings/BindingException.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nelibur.ObjectMapper.Bindings
+{
+	/// <summary>
+	/// Exception occurred during Binding
+	/// </summary>
+	public class BindingException : TinyMapperException
+	{
+		public BindingException()
+		{
+		}
+
+		public BindingException(string message) : base(message)
+		{
+		}
+
+		public BindingException(string message, Exception innerException) : base(message, innerException)
+		{
+		}
+
+		protected BindingException(SerializationInfo info, StreamingContext context) : base(info, context)
+		{
+		}
+	}
+}

--- a/Source/TinyMapper/ITinyMapperConfig.cs
+++ b/Source/TinyMapper/ITinyMapperConfig.cs
@@ -2,9 +2,30 @@
 
 namespace Nelibur.ObjectMapper
 {
+    /// <summary>
+    /// Configuration for TinyMapper
+    /// </summary>
     public interface ITinyMapperConfig
     {
+        /// <summary>
+        /// Allow mapping from a base class if a mapping for something more specific is unavailable
+        /// </summary>
+        bool EnablePolymorphicMapping { get; set; }
+
+        /// <summary>
+        /// Create an automatic binding based on property names
+        /// </summary>
+        bool EnableAutoBinding { get; set; }
+
+        /// <summary>
+        /// Custom name matching function used for auto bindings
+        /// </summary>
+        /// <param name="nameMatching">Function to match names</param>
         void NameMatching(Func<string, string, bool> nameMatching);
+
+        /// <summary>
+        /// Reset settings to default
+        /// </summary>
         void Reset();
     }
 }

--- a/Source/TinyMapper/Mappers/MappingException.cs
+++ b/Source/TinyMapper/Mappers/MappingException.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nelibur.ObjectMapper.Mappers
+{
+	/// <summary>
+	/// Exception during the mapping stage
+	/// </summary>
+	public class MappingException : TinyMapperException
+	{
+		public MappingException()
+		{
+		}
+
+		public MappingException(string message) : base(message)
+		{
+		}
+
+		public MappingException(string message, Exception innerException) : base(message, innerException)
+		{
+		}
+
+		protected MappingException(SerializationInfo info, StreamingContext context) : base(info, context)
+		{
+		}
+	}
+}

--- a/Source/TinyMapper/TinyMapper.cs
+++ b/Source/TinyMapper/TinyMapper.cs
@@ -10,6 +10,11 @@ using System.Threading;
 
 namespace Nelibur.ObjectMapper
 {
+    /// <summary>
+    /// TinyMapper is an object to object mapper for .NET. The main advantage is performance. 
+    /// TinyMapper allows easily map object to object, i.e. properties or fields from one 
+    /// object to another, for instance.
+    /// </summary>
     public static class TinyMapper
     {
         private static readonly Dictionary<TypePair, Mapper> _mappers = new Dictionary<TypePair, Mapper>();
@@ -24,6 +29,11 @@ namespace Nelibur.ObjectMapper
             _config = new TinyMapperConfig(_targetMapperBuilder);
         }
 
+        /// <summary>
+        /// Create a one-way mapping between one type and another
+        /// </summary>
+        /// <typeparam name="TSource">Source type</typeparam>
+        /// <typeparam name="TTarget">Target type</typeparam>
         public static void Bind<TSource, TTarget>()
         {
             TypePair typePair = TypePair.Create<TSource, TTarget>();
@@ -38,6 +48,12 @@ namespace Nelibur.ObjectMapper
             }
         }
 
+        /// <summary>
+        /// Create a one-way mapping between one type and another
+        /// </summary>
+        /// <typeparam name="TSource">Source type</typeparam>
+        /// <typeparam name="TTarget">Target type</typeparam>
+        /// <param name="config">BindingConfig for Custom Binding</param>
         public static void Bind<TSource, TTarget>(Action<IBindingConfig<TSource, TTarget>> config)
         {
             TypePair typePair = TypePair.Create<TSource, TTarget>();
@@ -56,6 +72,33 @@ namespace Nelibur.ObjectMapper
             }
         }
 
+        /// <summary>
+        /// Find out if a binding exists for Source to Target
+        /// </summary>
+        /// <typeparam name="TSource">Source type</typeparam>
+        /// <typeparam name="TTarget">Target type</typeparam>
+        /// <returns></returns>
+        public static bool BindingExists<TSource, TTarget>()
+        {
+            TypePair typePair = TypePair.Create<TSource, TTarget>();
+            bool result;
+            Mapper mapper;
+
+            _mappersLock.EnterReadLock();
+            result = _mappers.TryGetValue(typePair, out mapper);
+            _mappersLock.ExitReadLock();
+
+            return result;
+        }
+
+        /// <summary>
+        /// Coppies data from one class to another
+        /// </summary>
+        /// <typeparam name="TSource">Source type</typeparam>
+        /// <typeparam name="TTarget">Target type</typeparam>
+        /// <param name="source">Source object</param>
+        /// <param name="target">Target object (or null)</param>
+        /// <returns>Mapped object</returns>
         public static TTarget Map<TSource, TTarget>(TSource source, TTarget target = default(TTarget))
         {
             TypePair typePair = TypePair.Create<TSource, TTarget>();
@@ -66,13 +109,17 @@ namespace Nelibur.ObjectMapper
             return result;
         }
 
+        /// <summary>
+        /// Configure the Mapper
+        /// </summary>
+        /// <param name="config">Lambda to provide config settings</param>
         public static void Config(Action<ITinyMapperConfig> config)
         {
             config(_config);
         }
 
         /// <summary>
-        ///     Maps the specified source to <see cref="TTarget" /> type.
+        ///     Maps the specified source to TTarget /> type.
         /// </summary>
         /// <typeparam name="TTarget">The type of the target.</typeparam>
         /// <param name="source">The source value.</param>
@@ -101,8 +148,14 @@ namespace Nelibur.ObjectMapper
             {
                 if (_mappers.TryGetValue(typePair, out mapper) == false)
                 {
-                    mapper = _targetMapperBuilder.Build(typePair);
-                    _mappersLock.EnterWriteLock();
+                    if (_config.EnablePolymorphicMapping && (mapper = GetPolymorphicMapping(typePair)) != null)
+                    {
+                        return mapper;
+                    }
+                    else if (_config.EnableAutoBinding)
+                    {
+                        mapper = _targetMapperBuilder.Build(typePair);
+                        _mappersLock.EnterWriteLock();
                     try
                     {
                         _mappers[typePair] = mapper;
@@ -111,6 +164,9 @@ namespace Nelibur.ObjectMapper
                     {
                         _mappersLock.ExitWriteLock();
                     }
+                    }
+                    else
+                        throw new MappingException($"Unable to find a binding for type '{typePair.Source?.Name}' to '{typePair.Target?.Name}'.");
                 }
             }
             finally
@@ -119,6 +175,29 @@ namespace Nelibur.ObjectMapper
             }
 
             return mapper;
+        }
+
+        //Note: Lock should already be acquired for the mapper
+        private static Mapper GetPolymorphicMapping(TypePair types)
+        {
+            // Walk the polymorphic heirarchy until we find a mapping match
+            Type source = types.Source;
+            Mapper result = null;
+
+            do
+            {
+                foreach (var iface in source.GetInterfaces())
+                {
+                    if (_mappers.TryGetValue(TypePair.Create(iface, types.Target), out result))
+                        return result;
+                }
+
+                if (_mappers.TryGetValue(TypePair.Create(source, types.Target), out result))
+                    return result;
+
+            } while ((source = source.BaseType) != null);
+
+            return null;
         }
     }
 }

--- a/Source/TinyMapper/TinyMapper.csproj
+++ b/Source/TinyMapper/TinyMapper.csproj
@@ -22,6 +22,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <DocumentationFile>..\..\Out\Debug\TinyMapper\4.5\TinyMapper.xml</DocumentationFile>
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,6 +33,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <DocumentationFile>..\..\Out\Release\TinyMapper\4.5\TinyMapper.xml</DocumentationFile>
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release 4.0|AnyCPU'">
     <OutputPath>..\..\Out\Release\TinyMapper\4.0\</OutputPath>
@@ -44,6 +48,9 @@
     <Prefer32Bit>false</Prefer32Bit>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <DocumentationFile>..\..\Out\Release\TinyMapper\4.0\TinyMapper.xml</DocumentationFile>
+    <WarningLevel>4</WarningLevel>
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release 3.5|AnyCPU'">
     <OutputPath>..\..\Out\Release\TinyMapper\3.5\</OutputPath>
@@ -56,6 +63,8 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <DocumentationFile>..\..\Out\Release\TinyMapper\3.5\TinyMapper.xml</DocumentationFile>
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release 3.0|AnyCPU'">
     <OutputPath>..\..\Out\Release\TinyMapper\3.0\</OutputPath>
@@ -68,6 +77,8 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
     <TargetFrameworkVersion>v3.0</TargetFrameworkVersion>
+    <DocumentationFile>..\..\Out\Release\TinyMapper\3.0\TinyMapper.xml</DocumentationFile>
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -80,6 +91,7 @@
     <Compile Include="Bindings\BindingConfigAttributes.cs" />
     <Compile Include="Bindings\BindingConfig.cs" />
     <Compile Include="Bindings\BindingConfigOf.cs" />
+    <Compile Include="Bindings\BindingException.cs" />
     <Compile Include="Bindings\IBindingConfig.cs" />
     <Compile Include="CodeGenerators\Emitters\EmitArray.cs" />
     <Compile Include="CodeGenerators\Emitters\EmitThis.cs" />
@@ -99,6 +111,7 @@
     <Compile Include="Mappers\Classes\Members\MappingMemberBuilder.cs" />
     <Compile Include="Mappers\Classes\Members\MappingMember.cs" />
     <Compile Include="Core\Extensions\EnumerableExtensions.cs" />
+    <Compile Include="Mappers\MappingException.cs" />
     <Compile Include="Mappers\Types\Convertible\ConvertibleTypeMapper.cs" />
     <Compile Include="Mappers\Types\Convertible\ConvertibleTypeMapperBuilder.cs" />
     <Compile Include="Mappers\Types\Custom\CustomTypeMapper.cs" />
@@ -132,6 +145,7 @@
     <Compile Include="Core\Extensions\ObjectExtensions.cs" />
     <Compile Include="Core\Extensions\OptionExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TinyMapperException.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="nuget\tinymapper.nuspec" />

--- a/Source/TinyMapper/TinyMapperConfig.cs
+++ b/Source/TinyMapper/TinyMapperConfig.cs
@@ -7,6 +7,9 @@ namespace Nelibur.ObjectMapper
     {
         private readonly TargetMapperBuilder _targetMapperBuilder;
 
+        public bool EnablePolymorphicMapping { get; set; } = true;
+        public bool EnableAutoBinding { get; set; } = true;
+
         public TinyMapperConfig(TargetMapperBuilder targetMapperBuilder)
         {
             if (targetMapperBuilder == null)
@@ -28,6 +31,8 @@ namespace Nelibur.ObjectMapper
         public void Reset()
         {
             _targetMapperBuilder.SetNameMatching(TargetMapperBuilder.DefaultNameMatching);
+            EnableAutoBinding = true;
+            EnablePolymorphicMapping = true;
         }
     }
 }

--- a/Source/TinyMapper/TinyMapperException.cs
+++ b/Source/TinyMapper/TinyMapperException.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nelibur.ObjectMapper
+{
+	/// <summary>
+	/// Exception during mapping or binding
+	/// </summary>
+	public class TinyMapperException : Exception
+	{
+		public TinyMapperException()
+		{
+		}
+
+		public TinyMapperException(string message) : base(message)
+		{
+		}
+
+		public TinyMapperException(string message, Exception innerException) : base(message, innerException)
+		{
+		}
+
+		protected TinyMapperException(SerializationInfo info, StreamingContext context) : base(info, context)
+		{
+		}
+	}
+}

--- a/Source/UnitTests/Mappings/Polymorphic/PolymorphicTests.cs
+++ b/Source/UnitTests/Mappings/Polymorphic/PolymorphicTests.cs
@@ -1,0 +1,154 @@
+﻿using Nelibur.ObjectMapper;
+using Nelibur.ObjectMapper.Mappers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace UnitTests.Mappings.Polymorphic
+{
+	public class PolymorphicTests
+	{
+		[Fact]
+		public void SimpleCustomHeirarchyMappingTest()
+		{
+			// Arrange
+			SourceB source = new SourceB
+			{
+				FirstName = "John",
+				LastName = "Doe",
+				Age = 37
+			};
+
+			TargetA target = null;
+			TinyMapper.Bind<SourceA, TargetA>(n => n.Bind(from => from.FirstName, to => to.Name));
+
+			// Act
+			target = TinyMapper.Map<TargetA>(source);
+
+			// Assert
+			Assert.NotNull(target);
+			Assert.Same(source.FirstName, target.Name);
+		}
+
+		[Fact]
+		public void SimpleCustomHeirarchyMappingTest2()
+		{
+			// Arrange
+			SourceB source = new SourceB
+			{
+				FirstName = "John",
+				LastName = "Doe",
+				Age = 37
+			};
+
+			TargetB target = new TargetB();
+			TinyMapper.Bind<SourceA, TargetA>(n => n.Bind(from => from.FirstName, to => to.Name));
+
+			// Act
+			TinyMapper.Map<SourceA, TargetA>(source, target);
+
+			// Assert
+			Assert.NotNull(target);
+			Assert.Same(source.FirstName, target.Name);
+		}
+
+		[Fact]
+		public void SimpleCustomInterfaceMappingTest()
+		{
+			// Arrange
+			SourceB source = new SourceB
+			{
+				FirstName = "John",
+				LastName = "Doe",
+				Age = 37
+			};
+
+			TargetA target = null;
+			TinyMapper.Bind<ISource, TargetA>(n => n.Bind(from => from.FirstName, to => to.Name));
+
+			// Act
+			target = TinyMapper.Map<TargetA>(source);
+
+			// Assert
+			Assert.NotNull(target);
+			Assert.Same(source.FirstName, target.Name);
+		}
+
+		[Fact]
+		public void ReversePolymorphicShouldFailWithException()
+		{
+			// Arrange
+			TinyMapper.Config(n => n.EnableAutoBinding = false);
+
+			SourceB source = new SourceB
+			{
+				FirstName = "John",
+				LastName = "Doe",
+				Age = 37
+			};
+
+			// Act / Assert
+			Assert.Throws<MappingException>(() => TinyMapper.Map<TargetB>(source));
+		}
+
+		[Fact]
+		public void DisablePolymorphicMappingTest()
+		{
+			// Arrange
+			TinyMapper.Config(n => 
+			{
+				n.EnablePolymorphicMapping = false;
+			});
+
+			SourceB source = new SourceB
+			{
+				FirstName = "John",
+				LastName = "Doe",
+				Age = 37
+			};
+
+			TargetA target = null;
+			// This binding will be ignored because it will not be recognised as a binding for these types
+			TinyMapper.Bind<SourceA, TargetA>(n => n.Bind(from => from.FirstName, to => to.Name));
+
+			// Act
+			target = TinyMapper.Map<TargetA>(source);
+
+			// Assert
+			Assert.NotEqual(source.FirstName, target.Name);
+
+		}
+
+	}
+
+	public class SourceA
+	{
+		public string FirstName { get; set; }
+		public string LastName { get; set; }
+	}
+
+	public class SourceB : SourceA, ISource
+	{
+		public int Age { get; set; }
+	}
+
+	public interface ISource
+	{
+		int Age { get; set; }
+		string FirstName { get; set; }
+		string LastName { get; set; }
+	}
+
+	public class TargetA
+	{
+		public string Name { get; set; }
+	}
+
+	public class TargetB : TargetA
+	{
+		public int Age { get; set; }
+	}
+}

--- a/Source/UnitTests/UnitTests.csproj
+++ b/Source/UnitTests/UnitTests.csproj
@@ -82,6 +82,7 @@
   <ItemGroup>
     <Compile Include="Mappings\Collections\CollectionMappingTests.cs" />
     <Compile Include="Mappings\MapWithCustomBindTests.cs" />
+    <Compile Include="Mappings\Polymorphic\PolymorphicTests.cs" />
     <Compile Include="TinyMapperConfigTests.cs" />
     <Compile Include="Mappings\TypeConverters\ConvertibleTypeMappingTests.cs" />
     <Compile Include="Mappings\Collections\DictionaryMappingTests.cs" />


### PR DESCRIPTION
- Added Polymorphic mapping which will use a base type registration before creating a new registration (this is a very common problem with Entity Framework as the proxy generated is a new type that inherits from a base type. As mapping from Entity Framework is a major use-case for an object to object mapper, this is an important feature)

- Added the ability to map via interface types
- Added Exceptions types
- Added settings to disable automatic mapping and/or polymorphic Mapping
- Added XMLDoc comments so the .xml file can be shipped with the nuget package
- Added a BindingExists function that will tell you if a binding is already registered for a given source/dest
- Added Unit Tests for polymorphic mapping